### PR TITLE
Fix pyproject.toml correct instalation of the main pypsa-pl package by poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "PyPSA-PL: optimisation model of the Polish energy system"
 authors = ["Patryk Kubiczek <patryk.kubiczek@instrat.pl>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "pypsa_pl" from = "src"}]
+packages = [{include = "pypsa_pl", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "PyPSA-PL: optimisation model of the Polish energy system"
 authors = ["Patryk Kubiczek <patryk.kubiczek@instrat.pl>"]
 license = "MIT"
 readme = "README.md"
-packages = [{include = "src/pypsa_pl"}]
+packages = [{include = "pypsa_pl" from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Poetry raises an error because it does not install the main pypsa-pl package correctly.